### PR TITLE
Moved crc32 function to the local namespace

### DIFF
--- a/crc-collision.py
+++ b/crc-collision.py
@@ -2,14 +2,16 @@
 #Naive brute-forcing of CRC32 using spaces
 import binascii
 
+crc32 = binascii.crc32
+
 t = '{"auth_url": "https://www.google.com"}'
-tc = binascii.crc32(t)
+tc = crc32(t)
 
 #padding bytes; start with guess
 p = 0
 ai = '{"auth_url": "https://www.evil.example"}'
 a = ai.ljust(p - len(ai))
-ac = binascii.crc32(a)
+ac = crc32(a)
 
 attempt = 1
 
@@ -21,9 +23,9 @@ while True:
         print 'Attempt %i (p=%i): %s != %s' % (attempt, p, tc, ac)
     if p % 2**32 == 0:
         print 'Wrapped'
-        ac = binascii.crc32(ai)
+        ac = crc32(ai)
         p = 1
     else:
-        ac = binascii.crc32(' ', ac)
+        ac = crc32(' ', ac)
         p += 1
     attempt += 1


### PR DESCRIPTION
Moved crc32 function to the local namespace to reduce namespace lookup times.